### PR TITLE
4.2.6 Swarm上でMySQLをデプロイしてもコンテナが起動しない（Issues #5）に対する修正案

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM mysql:5.7
 
 # (1) パッケージアップデートとwgetインストール
-RUN apt-get update
-RUN apt-get install -y wget
+RUN yum update -y
+RUN yum install -y wget
+RUN yum install -y hostname
+
 
 # (2) entrykitのインストール
 RUN wget https://github.com/progrium/entrykit/releases/download/v0.4.0/entrykit_0.4.0_linux_x86_64.tgz
@@ -22,9 +24,9 @@ COPY sql /sql
 # (4) スクリプトとmysqldの実行
 ENTRYPOINT [ \
   "prehook", \
-    "add-server-id.sh", \
-    "--", \
+  "add-server-id.sh", \
+  "--", \
   "docker-entrypoint.sh" \
-]
+  ]
 
 CMD ["mysqld"]

--- a/etc/mysql/mysql.conf.d/mysqld.cnf
+++ b/etc/mysql/mysql.conf.d/mysqld.cnf
@@ -12,5 +12,5 @@ symbolic-links=0
 relay-log=mysqld-relay-bin 
 relay-log-index=mysqld-relay-bin 
 
-log-bin=/var/log/mysql/mysql-bin.log
+log-bin=/var/lib/mysql/mysql-bin.index
 


### PR DESCRIPTION
Close #5 
投稿したIssues #5 に対して、試行錯誤してデプロイに成功しました。
修正した内容をPull requestいたします。
コンテナ開発を学習上でバイブルとなる本だと思っています。
他の方にも勧めています。

＜修正内容＞
- Dockerfile：最新のMySQL5.7はベースイメージがOralceLinuxになっているようなので、パッケージ更新をyumコマンドに変更＆デフォルトはhostnameコマンドが使用できなかったのでInstallを追加
- mysqld.cnf：デフォルトのログ出力先が変更となっているよなので、バイナリログの出力先を修正